### PR TITLE
Expand SCR template with flextable example

### DIFF
--- a/inst/rmarkdown/templates/SCR/skeleton/01_body.Rmd
+++ b/inst/rmarkdown/templates/SCR/skeleton/01_body.Rmd
@@ -23,6 +23,21 @@ ggplot(d) +
     geom_point(aes(x = SSB, y = Recruitment))
 ```
 
+The template can also include publication-ready tables. For example, see Table \@ref(tab:example-flextable):
+
+```{r example-flextable, tab.cap = "Example table created with flextable."}
+example_tbl <- data.frame(
+    Year = 2021:2025,
+    Catch_t = c(1240, 1310, 1195, 1430, 1385),
+    Index = c(0.92, 1.01, 0.97, 1.08, 1.04)
+)
+
+flextable::flextable(example_tbl) |>
+    flextable::colformat_num(j = c("Catch_t", "Index"), digits = 2) |>
+    NAFOdown::theme_nafotabs()
+```
+
+
 # Discussion
 
 Discuss!


### PR DESCRIPTION
### Motivation
- Provide a concrete example of how to include publication-ready `flextable` tables in the SCR R Markdown skeleton so authors can copy a working snippet and produce NAFO-styled tables with captions and cross-references.

### Description
- Added a `flextable` example to the Results section of `inst/rmarkdown/templates/SCR/skeleton/01_body.Rmd` that follows an existing figure example and demonstrates a table cross-reference (`Table \@ref(tab:example-flextable)`).
- The new chunk (`example-flextable`) creates a sample data frame and renders it with `flextable::flextable`, formats numeric columns with `flextable::colformat_num`, and applies NAFO styling via `NAFOdown::theme_nafotabs()`.

### Testing
- Attempted to run `Rscript -e 'testthat::test_file("tests/testthat/test-render-scr.R")'`, but the command failed in this environment because `Rscript` is not available (`/bin/bash: line 1: Rscript: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bd34de088320a3a837934cb3d6c4)