### PR TITLE
Inject stock advice title tabs during Word render

### DIFF
--- a/R/make_word.R
+++ b/R/make_word.R
@@ -1,4 +1,62 @@
 
+
+.advice_title_tab_openxml <- "`<w:r><w:tab/></w:r>`{=openxml}"
+
+.inject_advice_title_tabs <- function(lines) {
+    in_title_div <- FALSE
+
+    vapply(lines, function(line) {
+        if (grepl('^:::\\s*\\{.*custom-style\\s*=\\s*["\']Title["\']', line)) {
+            in_title_div <<- TRUE
+            return(line)
+        }
+
+        if (in_title_div && grepl('^:::\\s*$', line)) {
+            in_title_div <<- FALSE
+            return(line)
+        }
+
+        if (in_title_div && grepl(" Advice", line, fixed = TRUE) &&
+            !grepl("<w:tab\\s*/>|\\tAdvice", line, perl = TRUE)) {
+            line <- sub(" Advice", paste0(.advice_title_tab_openxml, "Advice"),
+                        line, fixed = TRUE)
+        }
+
+        line
+    }, character(1), USE.NAMES = FALSE)
+}
+
+.inject_advice_title_tabs_file <- function(input_file) {
+    if (!file.exists(input_file)) {
+        return(invisible(FALSE))
+    }
+
+    lines <- readLines(input_file, warn = FALSE)
+    updated_lines <- .inject_advice_title_tabs(lines)
+
+    if (!identical(lines, updated_lines)) {
+        writeLines(updated_lines, input_file, useBytes = TRUE)
+        return(invisible(TRUE))
+    }
+
+    invisible(FALSE)
+}
+
+.add_advice_title_tab_pre_processor <- function(format) {
+    pre_processor <- format$pre_processor
+
+    format$pre_processor <- function(metadata, input_file, runtime, knit_meta,
+                                     files_dir, output_dir) {
+        .inject_advice_title_tabs_file(input_file)
+
+        if (is.function(pre_processor)) {
+            pre_processor(metadata, input_file, runtime, knit_meta, files_dir,
+                          output_dir)
+        }
+    }
+
+    format
+}
 .make_word_function <- function(format_function, reference_docx) {
     function(...) {
         base <- format_function(...,
@@ -6,7 +64,7 @@
                                 reference_docx = system.file("docx", reference_docx, package = "NAFOdown")
         )
         base$knitr$opts_chunk$comment <- NA
-        base
+        .add_advice_title_tab_pre_processor(base)
     }
 }
 

--- a/inst/rmarkdown/templates/SCS/skeleton/body.Rmd
+++ b/inst/rmarkdown/templates/SCS/skeleton/body.Rmd
@@ -1,7 +1,7 @@
 
 ::: {custom-style="Title"}
 
-__Species X in Divs. Y__`<w:r><w:tab/></w:r>`{=openxml}Advice XXXX for YYYY
+__Species X in Divs. Y__ Advice XXXX for YYYY
 
 :::
 

--- a/tests/testthat/test-advice-title-tabs.R
+++ b/tests/testthat/test-advice-title-tabs.R
@@ -1,0 +1,45 @@
+test_that("advice title tabs are injected in title custom styles", {
+  lines <- c(
+    '::: {custom-style="Title"}',
+    "",
+    "__Species X in Divs. Y__ Advice 2026 for 2027",
+    "",
+    ":::",
+    "Body Advice text stays unchanged"
+  )
+
+  updated <- NAFOdown:::.inject_advice_title_tabs(lines)
+
+  expect_identical(
+    updated[3],
+    "__Species X in Divs. Y__`<w:r><w:tab/></w:r>`{=openxml}Advice 2026 for 2027"
+  )
+  expect_identical(updated[6], lines[6])
+})
+
+test_that("advice title tabs are not duplicated", {
+  lines <- c(
+    '::: {custom-style="Title"}',
+    "__Species X in Divs. Y__`<w:r><w:tab/></w:r>`{=openxml}Advice 2026 for 2027",
+    ":::"
+  )
+
+  updated <- NAFOdown:::.inject_advice_title_tabs(lines)
+
+  expect_identical(updated, lines)
+})
+
+test_that("advice title tab injection updates markdown files", {
+  input_file <- tempfile(fileext = ".md")
+  writeLines(c(
+    '::: {custom-style="Title"}',
+    "__Species X in Divs. Y__ Advice 2026 for 2027",
+    ":::"
+  ), input_file)
+
+  changed <- NAFOdown:::.inject_advice_title_tabs_file(input_file)
+
+  expect_true(changed)
+  expect_true(grepl("<w:tab/>", readLines(input_file, warn = FALSE)[2],
+                    fixed = TRUE))
+})


### PR DESCRIPTION
### Motivation
- Allow authors to write stock summary titles with a normal space before "Advice" while ensuring a Word-compatible tab run is inserted at render time to right-justify the advice year. 
- Ensure injection is automatic only for title blocks (custom-style="Title") and avoid duplicating the OpenXML tab if authors already included it.

### Description
- Add an OpenXML run constant and three helper functions in `R/make_word.R`: `.advice_title_tab_openxml`, `.inject_advice_title_tabs()`, and `.inject_advice_title_tabs_file()` to detect title blocks and inject the tab run before the literal string ` Advice`.
- Add `.add_advice_title_tab_pre_processor()` and wrap the Word format returned by `.make_word_function()` so the injection runs as a pre-processor during render.
- Update the SCS skeleton example `inst/rmarkdown/templates/SCS/skeleton/body.Rmd` so the example title uses a normal space before `Advice` instead of embedded OpenXML.
- Add unit tests `tests/testthat/test-advice-title-tabs.R` that cover injection behavior, non-duplication when the tab already exists, and file mutation via `.inject_advice_title_tabs_file()`.

### Testing
- Unit tests were added at `tests/testthat/test-advice-title-tabs.R` to validate injection, no-ops for already-injected lines, and Markdown file updates.
- Automated package tests could not be executed in this environment because `Rscript` (the R runtime) is not available here, so the new tests were not run; please run `testthat` locally (for example via `Rscript -e "testthat::test_dir('tests/testthat')"`) to verify success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df009aeb483208bae4c7b29992fc1)